### PR TITLE
Ensure we're not duplicating labels

### DIFF
--- a/src/custom_include/include_processor.rs
+++ b/src/custom_include/include_processor.rs
@@ -41,10 +41,10 @@ impl<'a> IncludeProcessor<'a> {
 
     fn json_object_to_metric(&self, include_selector: &str, json_object: Value) -> Result<Vec<PromMetric>, CustomIncludeError> {
         let mut metrics = vec![];
-        let mut labels = self.labels(include_selector)?;
 
         if self.config.has_gauge_values() {
             for gauge_field_value in self.config.gauge_field_values.as_ref().unwrap() {
+                let mut labels = self.labels(include_selector)?;
                 labels.push(
                     PromLabel::new(self.config.gauge_field.to_string(), gauge_field_value.to_string())
                 );
@@ -57,6 +57,8 @@ impl<'a> IncludeProcessor<'a> {
             }
         } else {
             if let Some(json_value) = json_object.get(self.config.gauge_field.to_string()) {
+                let labels = self.labels(include_selector)?;
+
                 metrics.push(PromMetric::new(
                     self.include.name.to_string(),
                     utils::json_value_to_i64(json_value),

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -572,4 +572,15 @@ includes:
         assert!(metrics[0].labels.as_ref().unwrap().iter().find(|l| l.name == "backend").is_some());
         assert!(metrics[1].labels.as_ref().unwrap().iter().find(|l| l.name == "status").is_none());
     }
+
+    #[test]
+    fn convert_json_with_custom_include_no_duplicate_status_tags() {
+        let json_str = json_with_several_components();
+        let payload = Payload::new(json_str, Some(".components".into()), config_with_custom_includes());
+        let metrics = payload.json_to_metrics().unwrap();
+
+        for metric in metrics {
+            assert_eq!(metric.labels.as_ref().unwrap().iter().filter(|l| l.name == "status").count(), 1, "metric {} has more than one status label", metric.name);
+        }
+    }
 }


### PR DESCRIPTION
This fixes an issue where labels on custom includes got accidentally duplicated and therefore rendered the metric invalid