### PR TITLE
Global prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,14 @@ includes:
 `label_selector`: A valid `jq` selector to fetch the value for above-mentioned label.
 `selector`: One or more valid `jq` selectors that specify paths for JSON objects to retrieve
 
-Example:
+### Global Prefix
+
+If you'd like to add a prefix to all metrics so you can determine their origin, please add
+
+```yaml
+global_prefix: my_prefix
+```
+to your configuration file.
 
 ## Development
 

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -19,6 +19,7 @@ pub struct Include {
 pub struct ConfigFile {
     pub gauge_field: String,
     pub global_labels: Option<Vec<GlobalLabel>>,
+    pub global_prefix: Option<String>,
     pub gauge_field_values: Option<Vec<String>>,
     pub includes: Option<Vec<Include>>
 }

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -163,37 +163,41 @@ includes:
         config_file::ConfigFile::from_str(yaml_str).unwrap()
     }
 
-    #[test]
-    fn export_json_without_global_prefix() {
+    fn generate_metrics(config: &ConfigFile) -> String {
         let json_str = json_with_several_components();
-        let config = config_without_global_prefix();
         let payload = Payload::new(
             json_str,
             Some(".components".into()),
             &config,
         );
         let metrics = payload.json_to_metrics().unwrap();
-        let first_metric_name = metrics[0].name.to_string();
-
         let exporter = Exporter::new(&config, metrics);
-        let metrics_str = exporter.generate_metrics();
-        let metrics_payload = metrics_str.lines().collect::<Vec<_>>();
-        assert!(metrics_payload[0].starts_with(&first_metric_name));
+        let metrics_payload = exporter.generate_metrics();
+        metrics_payload
+    }
+
+    #[test]
+    fn export_json_without_global_prefix() {
+        let config = config_without_global_prefix();
+        let json_str = json_with_several_components();
+        let payload = Payload::new(
+            json_str,
+            Some(".components".into()),
+            &config,
+        );
+        let metrics = payload.json_to_metrics().unwrap();
+        let metric_name = metrics[0].name.to_string();
+        let exporter = Exporter::new(&config, metrics);
+        let metrics_payload = exporter.generate_metrics();
+        let lines = metrics_payload.lines().collect::<Vec<_>>();
+
+        assert!(lines[0].starts_with(&metric_name));
     }
 
     #[test]
     fn export_json_with_global_prefix() {
-        let json_str = json_with_several_components();
         let config = config_with_global_prefix();
-        let payload = Payload::new(
-            json_str,
-            Some(".components".into()),
-            &config,
-        );
-        let metrics = payload.json_to_metrics().unwrap();
-
-        let exporter = Exporter::new(&config, metrics);
-        let metrics_payload = exporter.generate_metrics();
+        let metrics_payload = generate_metrics(&config);
 
         for metric in metrics_payload.lines() {
             assert!(

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -1,0 +1,182 @@
+use crate::{config_file::ConfigFile, prom_metric::PromMetric};
+
+pub struct Exporter {
+    config: ConfigFile,
+    metrics: Vec<PromMetric>
+}
+
+impl Exporter {
+    pub(crate) fn new(config: ConfigFile, metrics: Vec<PromMetric>) -> Self {
+        Self {
+            config: config,
+            metrics: metrics
+        }
+    }
+
+    pub(crate) fn generate_metrics(&self) -> String {
+        let mut all_converted_metrics = vec!();
+
+        for metric in &self.metrics {
+            all_converted_metrics.push(self.metric_to_string(metric));
+        }
+
+        all_converted_metrics.join("\n").to_string()
+    }
+
+    fn metric_name(&self, metric: &PromMetric) -> String {
+        println!("{:?}", self.config.global_prefix);
+        if let Some(metric_prefix) = &self.config.global_prefix {
+            format!("{}_{}", metric_prefix, metric.name.to_string())
+        }
+        else {
+            metric.name.to_string()
+        }
+    }
+
+    fn metric_to_string(&self, metric: &PromMetric) -> std::string::String {
+        if metric.labels.is_none() {
+            format!("{} {}", self.metric_name(metric), metric.value.as_ref().unwrap_or(&0))
+        }
+        else {
+            let labels = metric.labels
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(|label| label.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+
+            format!("{}{{{}}} {}", self.metric_name(metric), labels, metric.value.as_ref().unwrap_or(&0))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{config_file::{self, ConfigFile}, payload::Payload};
+
+    use super::Exporter;
+
+    fn json_with_several_components() -> String {
+        r#"{
+            "environment": "production",
+            "id": "xyz",
+            "last_refresh_epoch": 1631046901,
+            "components": {
+                "network": {
+                    "status": "OK",
+                    "status_upstream": "active",
+                    "has_ip_addresses": true,
+                    "use_ip_v6": false,
+                    "upstream_endpoints": 54
+                },
+                "router": {
+                    "status": "Warning",
+                    "num_active_uplinks": 1,
+                    "num_uplinks": 2,
+                    "backend": {
+                        "back1": {
+                            "status": "warning",
+                            "total_count": 2,
+                            "healthy_count": 1,
+                            "unhealthy_count": 1
+                        },
+                        "back2": {
+                            "status": "warning",
+                            "total_count": 2,
+                            "healthy_count": 1,
+                            "unhealthy_count": 1
+                        }
+                    }
+                }
+            }
+        }"#
+        .to_string()
+    }
+
+    fn config_without_global_prefix() -> ConfigFile {
+        let yaml_str = r#"
+gauge_field: status
+gauge_field_values:
+  - warning
+  - ok
+global_labels:
+    - name: environment
+      selector: .environment
+    - name: id
+      selector: .id
+includes:
+    - name: router_backend_status
+      label_name: backend
+      label_selector: .router.backend
+      selector:
+        - ".router.backend.back1"
+        - ".router.backend.back2"
+"#;
+        config_file::ConfigFile::from_str(yaml_str).unwrap()
+    }
+
+    fn config_with_global_prefix() -> ConfigFile {
+        let yaml_str = r#"
+gauge_field: status
+gauge_field_values:
+  - warning
+  - ok
+global_prefix: prom_test
+global_labels:
+    - name: environment
+      selector: .environment
+    - name: id
+      selector: .id
+includes:
+    - name: router_backend_status
+      label_name: backend
+      label_selector: .router.backend
+      selector:
+        - ".router.backend.back1"
+        - ".router.backend.back2"
+"#;
+        config_file::ConfigFile::from_str(yaml_str).unwrap()
+    }
+
+    #[test]
+    fn export_json_without_global_prefix() {
+        let json_str = json_with_several_components();
+        let payload = Payload::new(
+            json_str,
+            Some(".components".into()),
+            config_without_global_prefix(),
+        );
+        let metrics = payload.json_to_metrics().unwrap();
+        let first_metric_name = metrics[0].name.to_string();
+
+        let exporter = Exporter::new(config_without_global_prefix(), metrics);
+        let metrics_str = exporter.generate_metrics();
+        let metrics_payload = metrics_str.lines().collect::<Vec<_>>();
+        println!("{:?}", metrics_payload[0]);
+        assert!(metrics_payload[0].starts_with(&first_metric_name));
+    }
+
+    #[test]
+    fn export_json_with_global_prefix() {
+        let json_str = json_with_several_components();
+        let payload = Payload::new(
+            json_str,
+            Some(".components".into()),
+            config_with_global_prefix(),
+        );
+        let metrics = payload.json_to_metrics().unwrap();
+
+        let exporter = Exporter::new(config_with_global_prefix(), metrics);
+        let metrics_payload = exporter.generate_metrics();
+
+        for metric in metrics_payload.lines() {
+            println!("METRIC {:?}", metric);
+            assert!(
+                metric.starts_with("prom_test"),
+                "Expected metric name {} to start with prefix 'prom_test'",
+                metric
+            );
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use crate::config_file::ConfigFile;
 use clap::{AppSettings, Clap};
+use exporter::Exporter;
 use rocket::http::Status;
 use rocket::response::{content, status};
 
@@ -39,13 +40,10 @@ async fn fetch_json(json_endpoint: String) -> Result<String, reqwest::Error> {
 
 fn process_json(config_file_path: &str, json_entry_point: String, body: String) -> Option<String> {
     let config = ConfigFile::from_file(config_file_path).unwrap();
-    let json_payload = payload::Payload::new(body, Some(json_entry_point), config);
+    let json_payload = payload::Payload::new(body, Some(json_entry_point), &config);
     if let Ok(converted_metrics) = json_payload.json_to_metrics() {
-        Some(converted_metrics
-            .into_iter()
-            .map(|metric| metric.to_string())
-            .collect::<Vec<_>>()
-            .join("\n"))
+        let exporter = Exporter::new(&config, converted_metrics);
+        Some(exporter.generate_metrics())
     }
     else {
         None

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod selector_error;
 mod payload_error;
 mod json_object_processor;
 mod custom_include;
+mod exporter;
 
 #[derive(Clap)]
 #[clap(version = "1.0", author = "Epsagon")]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -309,6 +309,29 @@ includes:
         config_file::ConfigFile::from_str(yaml_str).unwrap()
     }
 
+    fn config_with_global_prefix() -> ConfigFile {
+        let yaml_str = r#"
+gauge_field: status
+gauge_field_values:
+  - warning
+  - ok
+global_prefix: prom_test
+global_labels:
+    - name: environment
+      selector: .environment
+    - name: id
+      selector: .id
+includes:
+    - name: router_backend_status
+      label_name: backend
+      label_selector: .router.backend
+      selector:
+        - ".router.backend.back1"
+        - ".router.backend.back2"
+"#;
+        config_file::ConfigFile::from_str(yaml_str).unwrap()
+    }
+
     fn create_metrics() -> Vec<PromMetric> {
         let json_str = full_json_file();
         let payload = Payload::new(json_str, Some(".components".into()), config_without_gauge_mapping());

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -11,15 +11,15 @@ use crate::utils;
 use crate::selector_error::SelectorError;
 use crate::payload_error::PayloadError;
 
-pub struct Payload {
+pub struct Payload<'a> {
     full_json_document: String,
     payload_document: String,
-    config: ConfigFile,
+    config: &'a ConfigFile,
     jq: Jq
 }
 
-impl Payload {
-    pub fn new(json: String, json_entry_point: Option<String>, config: ConfigFile) -> Self {
+impl<'a> Payload<'a> {
+    pub fn new(json: String, json_entry_point: Option<String>, config: &'a ConfigFile) -> Self {
         let jq = Jq::new().unwrap();
         let default_query = ".".to_string(); // `.` is the jq filter that returns the entire document
         let payload_document = jq.resolve_raw(&json, &json_entry_point.unwrap_or(default_query)).unwrap(); //TODO: "HANDLE THIS ERROR ACCORDINGLY"
@@ -309,39 +309,18 @@ includes:
         config_file::ConfigFile::from_str(yaml_str).unwrap()
     }
 
-    fn config_with_global_prefix() -> ConfigFile {
-        let yaml_str = r#"
-gauge_field: status
-gauge_field_values:
-  - warning
-  - ok
-global_prefix: prom_test
-global_labels:
-    - name: environment
-      selector: .environment
-    - name: id
-      selector: .id
-includes:
-    - name: router_backend_status
-      label_name: backend
-      label_selector: .router.backend
-      selector:
-        - ".router.backend.back1"
-        - ".router.backend.back2"
-"#;
-        config_file::ConfigFile::from_str(yaml_str).unwrap()
-    }
-
     fn create_metrics() -> Vec<PromMetric> {
         let json_str = full_json_file();
-        let payload = Payload::new(json_str, Some(".components".into()), config_without_gauge_mapping());
+        let config = config_without_gauge_mapping();
+        let payload = Payload::new(json_str, Some(".components".into()), &config);
         payload.json_to_metrics().unwrap()
     }
 
     #[test]
     fn convert_json_object_no_entry_point() {
         let json_str = json_with_numeric_values();
-        let payload = Payload::new(json_str, None, config_without_gauge_mapping());
+        let config = config_without_gauge_mapping();
+        let payload = Payload::new(json_str, None, &config);
         let mut payload_names= payload.json_to_metrics()
                                         .unwrap()
                                         .iter()
@@ -362,7 +341,8 @@ includes:
         //We want to test what happens when we try to fetch global labels from the json
         //that do not exist
         let json_str = json_with_numeric_values();
-        let payload = Payload::new(json_str, None, config_with_non_existing_global_labels());
+        let config = config_with_non_existing_global_labels();
+        let payload = Payload::new(json_str, None, &config);
         match payload.json_to_metrics().unwrap_err() {
             PayloadError::SelectorError(err) => {
                 assert!(err.source().is_some());
@@ -376,7 +356,8 @@ includes:
     #[test]
     fn convert_json_object_no_entry_point_does_not_convert_child_object() {
         let json_str = json_with_numeric_values();
-        let payload = Payload::new(json_str, None, config_without_gauge_mapping());
+        let config = config_without_gauge_mapping();
+        let payload = Payload::new(json_str, None, &config);
         let metrics = payload.json_to_metrics().unwrap();
         let component_metric = metrics.iter().find(|m| m.name == "components");
 
@@ -454,7 +435,8 @@ includes:
     #[test]
     fn convert_full_json_with_root_entry_point_only_converts_numeric() {
         let json_str = full_json_file();
-        let payload = Payload::new(json_str, Some(".".into()), config_without_gauge_mapping());
+        let config = config_without_gauge_mapping();
+        let payload = Payload::new(json_str, Some(".".into()), &config);
         let metrics = payload.json_to_metrics().unwrap();
         assert_eq!(metrics[0].name, "last_refresh_epoch");
         assert_eq!(metrics[0].value, Some(1631046901));
@@ -463,7 +445,8 @@ includes:
     #[test]
     fn convert_full_json_with_root_entry_point_has_global_attributes() {
         let json_str = full_json_file();
-        let payload = Payload::new(json_str, Some(".".into()), config_without_gauge_mapping());
+        let config = config_without_gauge_mapping();
+        let payload = Payload::new(json_str, Some(".".into()), &config);
         let metrics = payload.json_to_metrics().unwrap();
         let labels = metrics[0].labels.as_ref().unwrap();
 
@@ -474,7 +457,8 @@ includes:
     #[test]
     fn convert_json_ensure_one_metric_per_gauge_value() {
         let json_str = json_with_several_components();
-        let payload = Payload::new(json_str, Some(".components".into()), config_with_gauge_mapping());
+        let config = config_with_gauge_mapping();
+        let payload = Payload::new(json_str, Some(".components".into()), &config);
         let metrics = payload.json_to_metrics().unwrap();
         assert_eq!(metrics.len(), 4);
     }
@@ -482,7 +466,8 @@ includes:
     #[test]
     fn convert_json_ensure_metric_per_gauge_value_has_correct_label() {
         let json_str = json_with_several_components();
-        let payload = Payload::new(json_str, Some(".components".into()), config_with_gauge_mapping());
+        let config = config_with_gauge_mapping();
+        let payload = Payload::new(json_str, Some(".components".into()), &config);
         let metrics = payload.json_to_metrics().unwrap();
 
         let first = metrics[0].labels.as_ref().unwrap();
@@ -497,7 +482,8 @@ includes:
     #[test]
     fn convert_json_ensure_metric_per_gauge_value_has_correct_flag() {
         let json_str = json_with_several_components();
-        let payload = Payload::new(json_str, Some(".components".into()), config_with_gauge_mapping());
+        let config = config_with_gauge_mapping();
+        let payload = Payload::new(json_str, Some(".components".into()), &config);
         let metrics = payload.json_to_metrics().unwrap();
 
         assert_eq!(metrics.len(), 4);
@@ -516,7 +502,8 @@ includes:
     #[test]
     fn convert_json_ensure_custom_includes_metric_has_correct_name() {
         let json_str = json_with_several_components();
-        let payload = Payload::new(json_str, Some(".components".into()),config_with_custom_includes());
+        let config = config_with_custom_includes();
+        let payload = Payload::new(json_str, Some(".components".into()),&config);
         let metrics = payload.json_to_metrics().unwrap();
 
         let custom_includes = metrics.iter().filter(|metric| metric.name == "router_backend_status")
@@ -529,7 +516,8 @@ includes:
     #[test]
     fn convert_json_ensure_custom_includes_metric_has_gauge_label() {
         let json_str = json_with_several_components();
-        let payload = Payload::new(json_str, Some(".components".into()),config_with_custom_includes());
+        let config = config_with_custom_includes();
+        let payload = Payload::new(json_str, Some(".components".into()), &config);
         let metrics = payload.json_to_metrics().unwrap();
         let custom_includes = metrics.iter().filter(|metric| metric.name == "router_backend_status")
                                 .collect::<Vec<_>>();
@@ -543,7 +531,8 @@ includes:
     #[test]
     fn convert_json_ensure_custom_includes_has_include_label() {
         let json_str = json_with_several_components();
-        let payload = Payload::new(json_str, Some(".components".into()),config_with_custom_includes());
+        let config = &config_with_custom_includes();
+        let payload = Payload::new(json_str, Some(".components".into()), config);
         let metrics = payload.json_to_metrics().unwrap();
         let custom_includes = metrics.iter().filter(|metric| metric.name == "router_backend_status")
                                 .collect::<Vec<_>>();
@@ -559,7 +548,8 @@ includes:
     #[test]
     fn convert_json_custom_include_with_invalid_selector_returns_error() {
         let json_str = json_with_several_components();
-        let payload = Payload::new(json_str, Some(".components".into()),config_with_custom_includes_and_invalid_label_selector());
+        let config = config_with_custom_includes_and_invalid_label_selector();
+        let payload = Payload::new(json_str, Some(".components".into()), &config);
         let metrics_or_error= payload.json_to_metrics();
         assert!(metrics_or_error.is_err());
         assert_matches!(metrics_or_error.unwrap_err(), PayloadError::SelectorError(_));
@@ -568,7 +558,8 @@ includes:
     #[test]
     fn convert_json_custom_include_without_gauge_values_returns_four_metrics() {
         let json_str =  json_with_numerical_status();
-        let payload = Payload::new(json_str, Some(".components".into()), config_with_custom_include_and_no_gauge_field_values());
+        let config = config_with_custom_include_and_no_gauge_field_values();
+        let payload = Payload::new(json_str, Some(".components".into()), &config);
         let metrics = payload.json_to_metrics().unwrap();
         //We need 2 metrics for everything directly under `components`
         //Plus two for the custom include
@@ -578,7 +569,8 @@ includes:
     #[test]
     fn convert_json_custom_include_without_gauge_values_custom_include_metrics_have_the_right_format() {
         let json_str =  json_with_numerical_status();
-        let payload = Payload::new(json_str, Some(".components".into()), config_with_custom_include_and_no_gauge_field_values());
+        let config = config_with_custom_include_and_no_gauge_field_values();
+        let payload = Payload::new(json_str, Some(".components".into()), &config);
         let metrics = payload.json_to_metrics().unwrap();
         let metrics = metrics.iter()
                 .filter(|m| m.name == "router_backend_status")
@@ -599,7 +591,8 @@ includes:
     #[test]
     fn convert_json_with_custom_include_no_duplicate_status_tags() {
         let json_str = json_with_several_components();
-        let payload = Payload::new(json_str, Some(".components".into()), config_with_custom_includes());
+        let config = config_with_custom_includes();
+        let payload = Payload::new(json_str, Some(".components".into()), &config);
         let metrics = payload.json_to_metrics().unwrap();
 
         for metric in metrics {

--- a/src/prom_metric.rs
+++ b/src/prom_metric.rs
@@ -16,23 +16,3 @@ impl PromMetric {
         }
     }
 }
-
-impl ToString for PromMetric {
-    fn to_string(&self) -> std::string::String {
-
-        if self.labels.is_none() {
-            format!("{} {}", self.name, self.value.as_ref().unwrap_or(&0))
-        }
-        else {
-            let labels = self.labels
-                .as_ref()
-                .unwrap()
-                .iter()
-                .map(|label| label.to_string())
-                .collect::<Vec<_>>()
-                .join(",");
-
-            format!("{}{{{}}} {}", self.name, labels, self.value.as_ref().unwrap_or(&0))
-        }
-    }
-}


### PR DESCRIPTION
This PR ships with a new feature: Global Prefixes.

To better tell apart metrics generated by this exporter users now can configure a global prefix that will be prepended to all metrics.